### PR TITLE
Show/Hide child nodes feature + Node refactor

### DIFF
--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -30,7 +30,7 @@ export default function Node(props: NodeProps) {
 
 	if (props.root) {
 		return <div>
-			<div className="Node" onClick={onNodeClick} ><div className="Arrow" /><div className="NodeText">{`_`}</div><div className="Arrow" /></div>
+			<div className="Node" onClick={onNodeClick} ><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{`_`}</div><div className="Arrow" /></div>
 			{expandState ? <div className="Level">
 				<Node jsonObj={jsonObj} />
 			</div> : null}
@@ -43,7 +43,7 @@ export default function Node(props: NodeProps) {
 				{!expandState ? null : Object.entries(jsonObj).map(([key, value]) => {
 					if (typeof value === 'object') {
 						return <div>
-							<div className="Node" onClick={onNodeClick}>{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div>
+							<div className="Node" onClick={onNodeClick}><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div><div className="Arrow" /></div>
 							{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `"${subitem}"` : subitem}</div>)}</div> : <Node jsonObj={value} />}
 						</div>
 					} else {
@@ -60,7 +60,7 @@ export default function Node(props: NodeProps) {
 		level.map(([key, value]) => {
 			if (typeof value === 'object') {
 				return <div >
-					<div className="Node" onClick={onNodeClick}>{Array.isArray(value) ? "[ " : ""}{`"${key}"`}{Array.isArray(value) ? " ]" : ""}</div>
+					<div className="Node" onClick={onNodeClick}><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{Array.isArray(value) ? "[ " : ""}{`"${key}"`}{Array.isArray(value) ? " ]" : ""}</div><div className="Arrow" /></div>
 					{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `"${subitem}"` : subitem}</div>)}</div> : <Node jsonObj={value} />}
 				</div>;
 			} else {

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -44,11 +44,11 @@ export default function Node(props: NodeProps) {
 					if (typeof value === 'object') {
 						return <div>
 							<div className="Node" onClick={onNodeClick}>{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div>
-							{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
+							{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `"${subitem}"` : subitem}</div>)}</div> : <Node jsonObj={value} />}
 						</div>
 					} else {
 						const displayValue = typeof value === "string" ? `"${value}"` : value;
-						return <div className="Node Leaf">{`"${key}" : ` + displayValue}</div>
+						return <div className="Node Leaf">{(Array.isArray(jsonObj) ? "" : `"${key}" : `) + displayValue}</div>
 					}
 				})}
 			</div>

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -5,12 +5,14 @@ interface NodeProps {
 	jsonObj: JSON | null;
 	expand: boolean;
 	keyless: boolean;
+	root: boolean;
 }
 
 const defaultProps: NodeProps = {
 	jsonObj: null,
 	expand: true,
 	keyless: false,
+	root: false,
 }
 
 Node.defaultProps = defaultProps;
@@ -26,6 +28,14 @@ export default function Node(props: NodeProps) {
 		return <div className="Node">NULL</div>;
 	}
 
+	if (props.root) {
+		return <div>
+			<div className="Node" onClick={onNodeClick} >{`_`}</div>
+			{expandState ? <div className="Level">
+				<Node jsonObj={jsonObj} />
+			</div> : null}
+		</div>
+	}
 	if (props.keyless) {
 		return <div>
 			<div className="Node" onClick={onNodeClick}>{Array.isArray(jsonObj) ? `[ ` : `{ `}{`_`}{Array.isArray(jsonObj) ? ` ]` : ` }`}</div>

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -38,7 +38,7 @@ export default function Node(props: NodeProps) {
 	}
 	if (props.keyless) {
 		return <div>
-			<div className="Node" onClick={onNodeClick}>{Array.isArray(jsonObj) ? `[ ` : `{ `}{`_`}{Array.isArray(jsonObj) ? ` ]` : ` }`}</div>
+			<div className="Node" onClick={onNodeClick}><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{Array.isArray(jsonObj) ? `[ ` : `{ `}{`_`}{Array.isArray(jsonObj) ? ` ]` : ` }`}</div><div className="Arrow" /></div>
 			<div className="Level">
 				{!expandState ? null : Object.entries(jsonObj).map(([key, value]) => {
 					if (typeof value === 'object') {
@@ -52,7 +52,7 @@ export default function Node(props: NodeProps) {
 					}
 				})}
 			</div>
-		</div>
+		</div >
 	}
 
 	let level = Object.entries(jsonObj)

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -1,21 +1,56 @@
 import "./css/Node.css";
+import { useState } from "react";
 
 interface NodeProps {
 	jsonObj: JSON | null;
+	expand: boolean;
+	keyless: boolean;
 }
+
+const defaultProps: NodeProps = {
+	jsonObj: null,
+	expand: true,
+	keyless: false,
+}
+
+Node.defaultProps = defaultProps;
 
 export default function Node(props: NodeProps) {
 	const { jsonObj } = props;
+	const [expandState, setExpandState] = useState(props.expand);
 	if (jsonObj === null) {
 		return <div className="Node">NULL</div>;
 	}
+
+	if (props.keyless) {
+		return <div>
+			<div className="Node">{Array.isArray(jsonObj) ? `[ ` : `{ `}{`_`}{Array.isArray(jsonObj) ? ` ]` : ` }`}</div>
+			<div className="Level">
+				{Object.entries(jsonObj).map(([key, value]) => {
+					if (typeof value === 'object') {
+						return <div>
+							<div className="Node">{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div>
+							{Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
+						</div>
+					} else {
+						const displayValue = typeof value === "string" ? `"${value}"` : value;
+						return <div className="Node">{displayValue}</div>
+					}
+				})}
+			</div>
+		</div>
+	}
+	const onNodeClick = () => {
+		setExpandState((prev: boolean) => !prev)
+	}
+
 	let level = Object.entries(jsonObj)
 	return <div className="Level">{
 		level.map(([key, value]) => {
 			if (typeof value === 'object') {
 				return <div >
-					<div className="Node">{Array.isArray(value) ? "[ " : ""}{`"${key}"`}{Array.isArray(value) ? " ]" : ""}</div>
-					{Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <div ><div className="Node">{Array.isArray(subitem) ? "[ " : "{ "}{"_"}{Array.isArray(subitem) ? " ]" : " }"}</div><Node jsonObj={subitem} /></div> : <div className="Node">{typeof subitem === "string" ? `"${subitem}"` : subitem}</div>)}</div> : <Node jsonObj={value} />}
+					<div className="Node" onClick={onNodeClick}>{Array.isArray(value) ? "[ " : ""}{`"${key}"`}{Array.isArray(value) ? " ]" : ""}</div>
+					{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
 				</div>;
 			} else {
 				const displayValue = typeof value === "string" ? `"${value}"` : value;

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -18,19 +18,23 @@ Node.defaultProps = defaultProps;
 export default function Node(props: NodeProps) {
 	const { jsonObj } = props;
 	const [expandState, setExpandState] = useState(props.expand);
+
+	const onNodeClick = () => {
+		setExpandState((prev: boolean) => !prev)
+	}
 	if (jsonObj === null) {
 		return <div className="Node">NULL</div>;
 	}
 
 	if (props.keyless) {
 		return <div>
-			<div className="Node">{Array.isArray(jsonObj) ? `[ ` : `{ `}{`_`}{Array.isArray(jsonObj) ? ` ]` : ` }`}</div>
+			<div className="Node" onClick={onNodeClick}>{Array.isArray(jsonObj) ? `[ ` : `{ `}{`_`}{Array.isArray(jsonObj) ? ` ]` : ` }`}</div>
 			<div className="Level">
-				{Object.entries(jsonObj).map(([key, value]) => {
+				{!expandState ? null : Object.entries(jsonObj).map(([key, value]) => {
 					if (typeof value === 'object') {
 						return <div>
-							<div className="Node">{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div>
-							{Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
+							<div className="Node" onClick={onNodeClick}>{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div>
+							{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
 						</div>
 					} else {
 						const displayValue = typeof value === "string" ? `"${value}"` : value;
@@ -39,9 +43,6 @@ export default function Node(props: NodeProps) {
 				})}
 			</div>
 		</div>
-	}
-	const onNodeClick = () => {
-		setExpandState((prev: boolean) => !prev)
 	}
 
 	let level = Object.entries(jsonObj)

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -30,7 +30,7 @@ export default function Node(props: NodeProps) {
 
 	if (props.root) {
 		return <div>
-			<div className="Node" onClick={onNodeClick} >{`_`}</div>
+			<div className="Node" onClick={onNodeClick} ><div className="Arrow" /><div className="NodeText">{`_`}</div><div className="Arrow" /></div>
 			{expandState ? <div className="Level">
 				<Node jsonObj={jsonObj} />
 			</div> : null}

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -4,71 +4,47 @@ import { useState } from "react";
 interface NodeProps {
 	jsonObj: JSON | null;
 	expand: boolean;
-	keyless: boolean;
-	root: boolean;
+	keyText: string | null;
 }
 
 const defaultProps: NodeProps = {
 	jsonObj: null,
 	expand: true,
-	keyless: false,
-	root: false,
+	keyText: "",
 }
 
 Node.defaultProps = defaultProps;
 
 export default function Node(props: NodeProps) {
-	const { jsonObj } = props;
+	const { jsonObj, keyText } = props;
 	const [expandState, setExpandState] = useState(props.expand);
 
 	const onNodeClick = () => {
 		setExpandState((prev: boolean) => !prev)
 	}
-	if (jsonObj === null) {
-		return <div className="Node">NULL</div>;
-	}
 
-	if (props.root) {
-		return <div>
-			<div className="Node" onClick={onNodeClick} ><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{`_`}</div><div className="Arrow" /></div>
-			{expandState ? <div className="Level">
-				<Node jsonObj={jsonObj} />
-			</div> : null}
-		</div>
-	}
-	if (props.keyless) {
-		return <div>
-			<div className="Node" onClick={onNodeClick}><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{Array.isArray(jsonObj) ? `[ ` : `{ `}{`_`}{Array.isArray(jsonObj) ? ` ]` : ` }`}</div><div className="Arrow" /></div>
-			<div className="Level">
-				{!expandState ? null : Object.entries(jsonObj).map(([key, value]) => {
-					if (typeof value === 'object') {
-						return <div>
-							<div className="Node" onClick={onNodeClick}><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div><div className="Arrow" /></div>
-							{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `"${subitem}"` : subitem}</div>)}</div> : <Node jsonObj={value} />}
-						</div>
-					} else {
-						const displayValue = typeof value === "string" ? `"${value}"` : value;
-						return <div className="Node Leaf">{(Array.isArray(jsonObj) ? "" : `"${key}" : `) + displayValue}</div>
-					}
-				})}
-			</div>
-		</div >
+	if ((jsonObj === null) || (typeof jsonObj !== "object")) {
+		const displayValue = typeof jsonObj === "string" ? `"${jsonObj}"` : jsonObj;
+		return <div className="Node Leaf">{`"${keyText}" : ` + displayValue}</div>;
 	}
 
 	let level = Object.entries(jsonObj)
-	return <div className="Level">{
-		level.map(([key, value]) => {
-			if (typeof value === 'object') {
-				return <div >
-					<div className="Node" onClick={onNodeClick}><div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{Array.isArray(value) ? "[ " : ""}{`"${key}"`}{Array.isArray(value) ? " ]" : ""}</div><div className="Arrow" /></div>
-					{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `"${subitem}"` : subitem}</div>)}</div> : <Node jsonObj={value} />}
-				</div>;
-			} else {
-				const displayValue = typeof value === "string" ? `"${value}"` : value;
-				return <div className="Node Leaf">{`"${key}" : ` + displayValue}</div>;
-			}
-		})
-	}</div >;
-
-
+	return <div>
+		<div className="Node" onClick={onNodeClick}>
+			<div className={"Arrow" + (expandState ? "Open" : "")}>▶</div><div className="NodeText">{`${keyText}`}</div><div className="Arrow" />
+		</div>
+		{expandState ? <div className="Level">{
+			level.map(([key, value]) => {
+				if ((typeof value === "object") && (value !== null)) {
+					return <div>
+						<div className="Level"><Node keyText={(Array.isArray(value) ? "[ " : "{ ") + (Array.isArray(jsonObj) ? "_" : key) + (Array.isArray(value) ? " ]" : " }")} jsonObj={value} />
+						</div>
+					</div>
+				}
+				else {
+					const displayValue = typeof value === "string" ? `"${value}"` : value;
+					return <div className="Node Leaf">{(Array.isArray(jsonObj) ? "" : (`"${key}" : `)) + displayValue}</div>;
+				}
+			})
+		}</div > : null}</div>
 }

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -34,11 +34,11 @@ export default function Node(props: NodeProps) {
 					if (typeof value === 'object') {
 						return <div>
 							<div className="Node" onClick={onNodeClick}>{Array.isArray(value) ? "[ " : "{ "}{`"${key}"`}{Array.isArray(value) ? " ]" : " }"}</div>
-							{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
+							{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
 						</div>
 					} else {
 						const displayValue = typeof value === "string" ? `"${value}"` : value;
-						return <div className="Node">{displayValue}</div>
+						return <div className="Node Leaf">{`"${key}" : ` + displayValue}</div>
 					}
 				})}
 			</div>
@@ -51,11 +51,11 @@ export default function Node(props: NodeProps) {
 			if (typeof value === 'object') {
 				return <div >
 					<div className="Node" onClick={onNodeClick}>{Array.isArray(value) ? "[ " : ""}{`"${key}"`}{Array.isArray(value) ? " ]" : ""}</div>
-					{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node">{typeof subitem === "string" ? `${subitem}` : subitem}</div>)}</div> : <Node jsonObj={value} />}
+					{!expandState ? null : Array.isArray(value) ? <div className="Level">{(value as Array<any>).map((subitem) => (typeof subitem === 'object') ? <Node jsonObj={subitem} keyless={true} /> : <div className="Node Leaf">{typeof subitem === "string" ? `"${subitem}"` : subitem}</div>)}</div> : <Node jsonObj={value} />}
 				</div>;
 			} else {
 				const displayValue = typeof value === "string" ? `"${value}"` : value;
-				return <div className="Node">{`"${key} : "` + displayValue}</div>;
+				return <div className="Node Leaf">{`"${key}" : ` + displayValue}</div>;
 			}
 		})
 	}</div >;

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -25,7 +25,7 @@ export default function Node(props: NodeProps) {
 
 	if ((jsonObj === null) || (typeof jsonObj !== "object")) {
 		const displayValue = typeof jsonObj === "string" ? `"${jsonObj}"` : jsonObj;
-		return <div className="Node Leaf">{`"${keyText}" : ` + displayValue}</div>;
+		return <div className="Leaf">{`"${keyText}" : ` + displayValue}</div>;
 	}
 
 	let level = Object.entries(jsonObj)
@@ -43,7 +43,7 @@ export default function Node(props: NodeProps) {
 				}
 				else {
 					const displayValue = typeof value === "string" ? `"${value}"` : value;
-					return <div className="Node Leaf">{(Array.isArray(jsonObj) ? "" : (`"${key}" : `)) + displayValue}</div>;
+					return <div className="Leaf">{(Array.isArray(jsonObj) ? "" : (`"${key}" : `)) + displayValue}</div>;
 				}
 			})
 		}</div > : null}</div>

--- a/src/components/Visualizer.tsx
+++ b/src/components/Visualizer.tsx
@@ -4,5 +4,5 @@ import Node from './Node';
 export default function Visualizer() {
 	const { json, fileName } = useFileStore((state: any) => state);
 	if (!json) return null;
-	return <div><h1>{fileName}</h1><Node jsonObj={json} root={true} /></div>
+	return <div><h1>{fileName}</h1><Node jsonObj={json} keyText="_" /></div>
 }

--- a/src/components/Visualizer.tsx
+++ b/src/components/Visualizer.tsx
@@ -4,5 +4,5 @@ import Node from './Node';
 export default function Visualizer() {
 	const { json, fileName } = useFileStore((state: any) => state);
 	if (!json) return null;
-	return <div><h1>{fileName}</h1> <Node jsonObj={json} /></div>
+	return <div><h1>{fileName}</h1><Node jsonObj={json} root={true} /></div>
 }

--- a/src/components/css/Node.css
+++ b/src/components/css/Node.css
@@ -7,7 +7,7 @@
 	padding: 10px;
 	cursor: pointer;
 	white-space: nowrap;
-	width: 100%;
+	width: inherit;
 }
 
 .Leaf {

--- a/src/components/css/Node.css
+++ b/src/components/css/Node.css
@@ -1,6 +1,21 @@
+.Arrow {
+	transition: transform 0.5s ease-in-out;
+	transform: rotate(0deg);
+}
+
+.ArrowOpen {
+	transition: transform 0.5s ease-in-out;
+	transform: rotate(90deg);
+}
+
+.NodeText {
+	font-size: 1.2em;
+	font-weight: bold;
+}
+
 .Node {
 	display: flex;
-	justify-content: center;
+	justify-content: space-between;
 	align-items: center;
 	border: 2px solid #abc;
 	background-color: #fff;

--- a/src/components/css/Node.css
+++ b/src/components/css/Node.css
@@ -26,6 +26,14 @@
 }
 
 .Leaf {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	border: 2px solid #abc;
+	background-color: #fff;
+	padding: 10px;
+	white-space: nowrap;
+	width: inherit;
  	cursor: normal;
 }
 

--- a/src/components/css/Node.css
+++ b/src/components/css/Node.css
@@ -4,7 +4,13 @@
 	align-items: center;
 	border: 2px solid #abc;
 	background-color: #fff;
-	padding: 5px;
+	padding: 10px;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.Leaf {
+ 	cursor: normal;
 }
 
 .Level {

--- a/src/components/css/Node.css
+++ b/src/components/css/Node.css
@@ -7,6 +7,7 @@
 	padding: 10px;
 	cursor: pointer;
 	white-space: nowrap;
+	width: 100%;
 }
 
 .Leaf {


### PR DESCRIPTION
Adds clickable functionality to nodes to show/hide children. 

## Changes
- Triangle icon on left side of node to indicate shown/hidden children status
- Additional props added (expand, keyText) to Node.tsx. This is necessary for the show/hide feature
- Node.tsx refactored to allow individual node state control rather than level state control